### PR TITLE
Update documentation for installing standard stack

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ The stack that you will use to build and run the Docker images is comprised of t
 - Windows Subsystem for Linux
 - Ubuntu image for WSL
 
-After you have installed these you should be able build and run the Docker images inside of your Ubuntu virtual machine that runs on Hyper-V and Windows Subsystem for Linux. On a standard Windows 10 Pro machine, you must ensure that the Hyper-V and Windows Subsystem for Linux features are enabled first. See the [win10pro-wsl-ubuntu-tools instructions](win10pro-wsl-ubuntu-tools/README.md) for details on how to install and configure this stack.
+After you have installed these components you will be able to build and run the Docker images inside of your Ubuntu virtual machine that runs on Hyper-V and Windows Subsystem for Linux. On a standard Windows 10 Pro machine, you must ensure that the Hyper-V and Windows Subsystem for Linux features are enabled first. See the [win10pro-wsl-ubuntu-tools instructions](win10pro-wsl-ubuntu-tools/README.md) for details on how to install and configure this stack.
 
 Why do it this way?
 

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ The stack that you will use to build and run the Docker images is comprised of t
 - Windows Subsystem for Linux
 - Ubuntu image for WSL
 
-After you have installed these you should be able build and run the Docker images inside of your Ubuntu virtual machine that runs on Hyper-V and Windows Subsystem for Linux. On a Windows 10 Pro machine, you must ensure that the Hyper-V and Windows Subsystem for Linux features are enabled first. See [win10pro-wsl-ubuntu-tools instructions](win10pro-wsl-ubuntu-tools/README.md) for detailed instructions on how to install and configure this stack.
+After you have installed these you should be able build and run the Docker images inside of your Ubuntu virtual machine that runs on Hyper-V and Windows Subsystem for Linux. On a Windows 10 Pro machine, you must ensure that the Hyper-V and Windows Subsystem for Linux features are enabled first. See the [win10pro-wsl-ubuntu-tools instructions](win10pro-wsl-ubuntu-tools/README.md) for details on how to install and configure this stack.
 
 Why do it this way?
 

--- a/README.md
+++ b/README.md
@@ -59,10 +59,11 @@ The stack that you will use to build and run the Docker images is comprised of t
 
 - Windows 10 Pro
 - Hyper-V Virtualization
+- Docker for Windows
 - Windows Subsystem for Linux
 - Ubuntu image for WSL
 
-After you have installed these you should be able build and run the Docker images inside of your Ubuntu virtual machine that runs on Hyper-V and Windows Subsystem for Linux. On a Windows 10 Pro machine, you must ensure that the Hyper-V and Windows Subsystem for Linux features are enabled first. See the [win10pro-wsl-ubuntu-tools instructions](win10pro-wsl-ubuntu-tools/README.md) for details on how to install and configure this stack.
+After you have installed these you should be able build and run the Docker images inside of your Ubuntu virtual machine that runs on Hyper-V and Windows Subsystem for Linux. On a standard Windows 10 Pro machine, you must ensure that the Hyper-V and Windows Subsystem for Linux features are enabled first. See the [win10pro-wsl-ubuntu-tools instructions](win10pro-wsl-ubuntu-tools/README.md) for details on how to install and configure this stack.
 
 Why do it this way?
 

--- a/README.md
+++ b/README.md
@@ -55,16 +55,6 @@ As the name implies, the software is distributed via Docker. The user
 simply clones a Git repository and uses the command `docker-compose up`
 to bring up the services.
 
-The stack that you will use to build and run the Docker images is comprised of the following:
-
-- Windows 10 Pro
-- Hyper-V Virtualization
-- Docker for Windows
-- Windows Subsystem for Linux
-- Ubuntu image for WSL
-
-After you have installed these components you will be able to build and run the Docker images inside of your Ubuntu virtual machine that runs on Hyper-V and Windows Subsystem for Linux. On a standard Windows 10 Pro machine, you must ensure that the Hyper-V and Windows Subsystem for Linux features are enabled first. See the [win10pro-wsl-ubuntu-tools instructions](win10pro-wsl-ubuntu-tools/README.md) for details on how to install and configure this stack.
-
 Why do it this way?
 
 -   Provide a standardized common working environment for data

--- a/README.md
+++ b/README.md
@@ -55,6 +55,15 @@ As the name implies, the software is distributed via Docker. The user
 simply clones a Git repository and uses the command `docker-compose up`
 to bring up the services.
 
+The stack that you will use to build and run the Docker images is comprised of the following:
+
+- Windows 10 Pro
+- Hyper-V Virtualization
+- Windows Subsystem for Linux
+- Ubuntu image for WSL
+
+After you have installed these you should be able build and run the Docker images inside of your Ubuntu virtual machine that runs on Hyper-V and Windows Subsystem for Linux. On a Windows 10 Pro machine, you must ensure that the Hyper-V and Windows Subsystem for Linux features are enabled first. See [win10pro-wsl-ubuntu-tools instructions](win10pro-wsl-ubuntu-tools/README.md) for detailed instructions on how to install and configure this stack.
+
 Why do it this way?
 
 -   Provide a standardized common working environment for data

--- a/win10pro-wsl-ubuntu-tools/README.md
+++ b/win10pro-wsl-ubuntu-tools/README.md
@@ -1,11 +1,23 @@
 Using Docker from Windows 10 Pro / Windows Subsystem for Linux / Ubuntu
 ================
 
-Getting started
+Overview
+--------
+
+The stack that you will use to build and run the Docker images on Windows 10 Pro is comprised of the following:
+
+- Hyper-V Virtualization
+- Docker for Windows
+- Windows Subsystem for Linux
+- Ubuntu image for WSL
+
+After you have installed these components you will be able to build and run the Docker images inside of a Ubuntu virtual machine running on top of Hyper-V and Windows Subsystem for Linux. On a standard Windows 10 Pro machine, you must ensure that the Hyper-V and Windows Subsystem for Linux features are installed and enabled first. See the *Getting Started* section below for details on how to install and configure each of the components of this stack.
+
+Getting Started
 ---------------
 
 1.  You'll need Windows 10 Pro and Docker for Windows installed. See [Install Docker for Windows](https://docs.docker.com/docker-for-windows/install/).
-2.  Enable Hyper-V Windows Virtualization. See [Install Hyper-V on Windows 10](https://docs.microsoft.com/en-us/virtualization/hyper-v-on-windows/quick-start/enable-hyper-v). *Note: This disables the ability to run Oracle VirtualBox machines.*
+2.  Enable Hyper-V Windows Virtualization. See [Install Hyper-V on Windows 10](https://docs.microsoft.com/en-us/virtualization/hyper-v-on-windows/quick-start/enable-hyper-v). *Note: This disables the ability to run Oracle VirtualBox virtual machine images.*
 2.  Install Ubuntu for Windows Subsystem for Linux (WSL) from the Microsoft Store. (see [Install the Windows Subsystem for Linux](https://docs.microsoft.com/en-us/windows/wsl/install-win10#install-the-windows-subsystem-for-linux))
 3.  Read the blog post that explains what you're going to do - <https://blogs.msdn.microsoft.com/commandline/2017/12/08/cross-post-wsl-interoperability-with-docker/>.
 

--- a/win10pro-wsl-ubuntu-tools/README.md
+++ b/win10pro-wsl-ubuntu-tools/README.md
@@ -4,9 +4,11 @@ Using Docker from Windows 10 Pro / Windows Subsystem for Linux / Ubuntu
 Getting started
 ---------------
 
-1.  You'll need Windows 10 Pro and Docker for Windows installed.
-2.  Install Ubuntu for Windows Subsystem for Linux (WSL) from the Microsoft Store.
+1.  You'll need Windows 10 Pro and Docker for Windows installed. See [Install Docker for Windows](https://docs.docker.com/docker-for-windows/install/).
+2.  Enable Hyper-V Windows Virtualization. See [Install Hyper-V on Windows 10](https://docs.microsoft.com/en-us/virtualization/hyper-v-on-windows/quick-start/enable-hyper-v). *Note: This disables the ability to run Oracle VirtualBox machines.*
+2.  Install Ubuntu for Windows Subsystem for Linux (WSL) from the Microsoft Store. (see [Install the Windows Subsystem for Linux](https://docs.microsoft.com/en-us/windows/wsl/install-win10#install-the-windows-subsystem-for-linux))
 3.  Read the blog post that explains what you're going to do - <https://blogs.msdn.microsoft.com/commandline/2017/12/08/cross-post-wsl-interoperability-with-docker/>.
+
 
 Installation
 ------------


### PR DESCRIPTION
Installing the standard stack on a Windows 10 Pro laptop went smoothly, but a few minor updates to the documentation may make the process more understandable for future users. I added a brief description of the install stack and its components so the user understands what he/she is installing prior to going through the steps, as well as some links that I found useful to vendor documentation for the actual components. Please suggest any changes you would like to what I proposed.

Addresses issue #63.

 